### PR TITLE
Mentions need for Rust Nightly

### DIFF
--- a/user_guide/src/chapter_1.md
+++ b/user_guide/src/chapter_1.md
@@ -10,11 +10,15 @@ Vega requires Rust Nightly channel because it depends on libraries that require 
 Ensure that you have and are using a Nightly toolchain when
 building examples.
 
-    rustup toolchain install nightly
+```doc
+$ rustup toolchain install nightly
+```
     
 Then set the default, or pass the toolchain in when invoking Cargo:
 
-    rustup default nightly
+```doc
+$ rustup default nightly
+```
 
 ### Installing Vega
 

--- a/user_guide/src/chapter_1.md
+++ b/user_guide/src/chapter_1.md
@@ -4,11 +4,23 @@
 
 ## Getting started
 
-### Installation
+### Setting up Rust
 
-Right now the framework lacks any sort of cluster manager of submit program/script.
+Vega requires Rust Nightly channel because it depends on libraries that require Nightly (`serde_traitobject` -> `metatype`).
+Ensure that you have and are using a Nightly toolchain when
+building examples.
 
-In order to use the framework you have to clone the repository and add the local dependency or add the upstream GitHub repository to your Rust project (the crate is not yet published on [crates.io](https://crates.io/)). E.g. add to your application Cargo.toml or:
+    rustup toolchain install nightly
+    
+Then set the default, or pass the toolchain in when invoking Cargo:
+
+    rustup default nightly
+
+### Installing Vega
+
+Right now, the framework lacks any sort of cluster manager of submit program/script.
+
+In order to use the framework, you have to clone the repository and add the local dependency or add the upstream GitHub repository to your Rust project (the crate is not yet published on [crates.io](https://crates.io/)). E.g. add to your application Cargo.toml or:
 
 ```doc
 [dependencies]
@@ -17,7 +29,7 @@ vega = { path = "/path/to/local/git/repo" }
 vega = { git = "https://github.com/rajasekarv/vega", branch = "master }
 ```
 
-Is not recommended to use the application for any sort of production code yet as it's under heavy development.
+It is _not recommended_ to use the application for any sort of production code yet as it's under heavy development.
 
 Check [examples](https://github.com/rajasekarv/vega/tree/master/examples) and [tests](https://github.com/rajasekarv/vega/tree/master/tests) in the source code to get a basic idea of how the framework works.
 


### PR DESCRIPTION
Direct dependency `serde_traitobject` 0.2.4 depends on `metatype` 0.2.0, which requires nightly.